### PR TITLE
Add support for AhaDNS black- & white-lists and install aspnetcore-runtime during setup

### DIFF
--- a/files/scripts/bash/unbound_update.sh
+++ b/files/scripts/bash/unbound_update.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# This script will download the oisd.nl block list and create a unbound compatible block list
-# Author: NoExitTV
-# For: AhaDNS
+# This script will download the oisd.nl block list and create a unbound compatible block list.
+# The black- & white-list from the Aha.Dns.Domains is also used (source: https://github.com/AhaDNS/Aha.Dns.Domains)
+# Author: NoExitTV (Fredrik Pettersson)
+# For: AhaDNS.com
 #================================================================================
 TICK="[\e[32m ✔ \e[0m]"
 
@@ -11,14 +12,17 @@ if [ "$(id -u)" != "0" ] ; then
 fi
 
 echo "Triggered update of unbound blocklist"
-curl -sS https://hosts.oisd.nl/ | sudo tee -a blocklist.txt >/dev/null
-echo -e " ${TICK} \e[32m Downloaded blocklist from hosts.oisd.nl... \e[0m"
+curl -sS https://dbl.oisd.nl/ | sudo tee -a blocklist.txt >/dev/null
+echo -e " ${TICK} \e[32m Downloaded blocklist from dbl.oisd.nl... \e[0m"
+sleep 0.1
+curl -sS https://raw.githubusercontent.com/AhaDNS/Aha.Dns.Domains/master/Domains/blacklist.txt | sudo tee -a blocklist.txt >/dev/null
+echo -e " ${TICK} \e[32m Downloaded AhaDNS blacklist from the Aha.Dns.Domains repository... \e[0m"
 sleep 0.1
 echo -e " ${TICK} \e[32m Removing duplicates... \e[0m"
 mv blocklist.txt blocklist.txt.old && cat blocklist.txt.old | sort | uniq >> blocklist.txt
 sleep 0.1
 echo -e " ${TICK} \e[32m Converting to unbound format... \e[0m"
-cat blocklist.txt | grep '^0\.0\.0\.0' | awk '{print "local-zone: \""$2"\" always_refuse"}' > unbound_blocklist.conf
+cat blocklist.txt | grep '^[A-Za-z0-9åäöÅÄÖ]' | awk '{print "local-zone: \""$1"\" always_refuse"}' > unbound_blocklist.conf
 sleep 0.1
 echo -e " ${TICK} \e[32m Moving blocklist to unbound directory... \e[0m"
 sudo cp unbound_blocklist.conf /etc/unbound/unbound_blocklist.conf
@@ -33,14 +37,14 @@ echo "Triggered update of unbound whitelists"
 curl -sS https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt | sudo tee -a whitelist.txt >/dev/null
 echo -e " ${TICK} \e[32m Adding anudeepND's domains to whitelist... \e[0m"
 sleep 0.1
-curl -sS https://raw.githubusercontent.com/NoExitTV/pi-dns/master/domains/whitelist.txt | sudo tee -a whitelist.txt >/dev/null
-echo -e " ${TICK} \e[32m Adding pi-dns's domains to whitelist... \e[0m"
+curl -sS https://raw.githubusercontent.com/AhaDNS/Aha.Dns.Domains/master/Domains/whitelist.txt | sudo tee -a whitelist.txt >/dev/null
+echo -e " ${TICK} \e[32m Adding AhaDNS whitelist from Aha.Dns.Domains... \e[0m"
 sleep 0.1
 echo -e " ${TICK} \e[32m Removing duplicates... \e[0m"
 mv whitelist.txt whitelist.txt.old && cat whitelist.txt.old | sort | uniq >> whitelist.txt
 sleep 0.1
 echo -e " ${TICK} \e[32m Converting to unbound format... \e[0m"
-cat whitelist.txt | grep '^' | awk '{print "local-zone: \""$1"\" transparent"}' > unbound_whitelist.conf
+cat whitelist.txt | grep '^[A-Za-z0-9åäöÅÄÖ]' | awk '{print "local-zone: \""$1"\" transparent"}' > unbound_whitelist.conf
 sleep 0.1
 echo -e " ${TICK} \e[32m Moving whitelist to unbound directory... \e[0m"
 sudo cp unbound_whitelist.conf /etc/unbound/unbound_whitelist.conf

--- a/playbook.yml
+++ b/playbook.yml
@@ -53,6 +53,7 @@
           - unattended-upgrades
           - apt-listchanges
           - bsd-mailx
+          - apt-transport-https
       register: install_result
 
     - name: Enable nginx
@@ -602,10 +603,10 @@
     - name: Setup .NET apt repo
       apt: deb="/tmp/packages-microsoft-prod.deb"
 
-    - name: Install .NET runtime
+    - name: Install ASP.NET runtime
       apt:
         update_cache: true
-        name: "dotnet-runtime-{{ dotnetRuntimeVersion }}"
+        name: "aspnetcore-runtime-{{ dotnetRuntimeVersion }}"
 
   # # Handlers
   # handlers:


### PR DESCRIPTION
## Issues in PR
Issue #7 

## Summary
- Added support for white- & black-lists in Aha.Dns.Domains repository.
- Install aspnetcore-runtime instead of dotnet-runtime during setup.