### PR TITLE
Feature/fix issues with windows line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,17 @@
 All notable changes to this project will be documented in this file.  
 Type of changes can be `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
 
+## [1.1.0] - 2020-12-06
+
+### Fixed
+
+- Fixed issue with files potentially having Windows CR/LF line endings, making custom cron job in /etc/cron.d/ to not execute
+
 ## [1.0.2] - 2020-12-05
 
 ### Fixed
 
-- Fixed issue with accidental spaces in ahadns cron.d file making custom cronjobs to not execute
+- Fixed issue with accidental spaces in ahadns cron.d file making custom cron jobs to not execute
 
 ## [1.0.1] - 2020-12-04
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -103,6 +103,10 @@
         dest: /etc/sysctl.d/99-ahadns-sysctl.conf
         force: yes
         mode: "0644"
+    - name: Fix windows CR/LF line endings in /etc/sysctl.d/99-ahadns-sysctl.conf
+      replace:
+        path: /etc/sysctl.d/99-ahadns-sysctl.conf
+        regexp: "\r"
     - name: Reload sysctl
       shell: sysctl -p /etc/sysctl.d/99-ahadns-sysctl.conf
       become: true
@@ -120,6 +124,10 @@
             dest: /etc/apt/apt.conf.d/20auto-upgrades
             force: yes
             mode: "0644"
+        - name: Fix windows CR/LF line endings in /etc/apt/apt.conf.d/20auto-upgrades
+          replace:
+            path: /etc/apt/apt.conf.d/20auto-upgrades
+            regexp: "\r"
         - name: Set automatic reboot to true
           lineinfile:
             path: /etc/apt/apt.conf.d/50unattended-upgrades
@@ -359,6 +367,10 @@
             mode: "0644"
             force: yes
 
+    - name: Fix windows CR/LF line endings in /etc/cron.d/ahadns
+      replace:
+        path: /etc/cron.d/ahadns
+        regexp: "\r"
     - name: Fix windows CR/LF line endings in /etc/ahadns/unbound_update.sh
       replace:
         path: /etc/ahadns/unbound_update.sh
@@ -410,6 +422,10 @@
         dest: /etc/security/limits.d/99-ahadns-limits.conf
         mode: "0644"
         force: yes
+    - name: Fix windows CR/LF line endings in /etc/security/limits.d/99-ahadns-limits.conf
+      replace:
+        path: /etc/security/limits.d/99-ahadns-limits.conf
+        regexp: "\r"
     - name: Increase max open files in /etc/systemd/system.conf
       lineinfile:
         path: /etc/systemd/system.conf


### PR DESCRIPTION
# Pull Request Template

## Checklist

- [x] Is CHANGELOG updated?

## Summary

- Fixed issue with files potentially having Windows CR/LF line endings.
  - Made custom cron job in /etc/cron.d/ to not execute i.e. blocklist was never updated
