### PR TITLE
Misc optimizations and bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.  
 Type of changes can be `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
 
+## [2.0.0] - 2020-12-12
+
+### Fixed
+
+- Fixed issue where certbot could not renew certificates due to permissions & nginx binding on port 80
+  - Requires complete re-install of certificates
+
+### Changed
+
+- Tuning of Unbound, increased number of file descriptors
+- Set static cache size for Unbound, might be changed to dynamic later when stability is confirmed
+- Made golang version upgradable by always re-installing golang on each deploy
+- Updated m13253 DoH server to 2.2.4
+
 ## [1.1.0] - 2020-12-06
 
 ### Fixed

--- a/files/m13253-doh/doh-server.conf
+++ b/files/m13253-doh/doh-server.conf
@@ -46,3 +46,21 @@ verbose = false
 # Enable log IP from HTTPS-reverse proxy header: X-Forwarded-For or X-Real-IP
 # Note: http uri/useragent log cannot be controlled by this config
 log_guessed_client_ip = false
+
+# By default, non global IP addresses are never forwarded to upstream servers.
+# This is to prevent two things from happening:
+#   1. the upstream server knowing your private LAN addresses;
+#   2. the upstream server unable to provide geographically near results,
+#      or even fail to provide any result.
+# However, if you are deploying a split tunnel corporation network environment,
+# or for any other reason you want to inhibit this behavior, change the following
+# option to "true".
+ecs_allow_non_global_ip = false
+
+# If ECS is added to the request, let the full IP address or
+# cap it to 24 or 128 mask. This option is to be used only on private
+# networks where knwoledge of the terminal endpoint may be required for
+# security purposes (eg. DNS Firewalling). Not a good option on the
+# internet where IP address may be used to identify the user and
+# not only the approximate location.
+ecs_use_precise_ip = false

--- a/files/unbound/ahadns.conf
+++ b/files/unbound/ahadns.conf
@@ -68,8 +68,8 @@ server:
 
     # Ensure kernel buffer is large enough to not lose messages in traffic spikes
     # Max is increased by modifying /proc/sys/net/core/wmem_max and /proc/sys/net/core/rmem_max
-    so-rcvbuf: 4m
-    so-sndbuf: 4m
+    so-rcvbuf: 8m
+    so-sndbuf: 8m
 
     ## Unbound Optimization and Speed Tweaks ##
     ## From: https://www.safematix.com/software/dns/unbound-root-server-setup/
@@ -122,8 +122,10 @@ server:
     # total is rrset+msg*num_core?
     # On 1 core 1GB ram we use rrset-cache-size: 256m & msh-cache-size: 128m
     # On 1 core 2GB ram we use rrset-cache-size: 384 & msg-cache-size: 192 (Under asessment)
-    rrset-cache-size: {rrset_cache_mb}m
-    msg-cache-size: {msg_cache_mb}m
+    # rrset-cache-size: {rrset_cache_mb}m
+    # msg-cache-size: {msg_cache_mb}m
+    rrset-cache-size: 512m
+    msg-cache-size: 256m
 
     # IMPORTANT FOR TESTING: If you are testing and setup NSD or BIND  on
     # localhost you will want to allow the resolver to send queries to localhost.
@@ -139,3 +141,10 @@ server:
     # otherwise it is inactive, the unbound-control status command shows if it is active).
     so-reuseport: yes
     
+    # Increase number of file descriptors
+    outgoing-range: 8192
+    num-queries-per-thread: 4096
+
+#
+# End of AhaDNS unbound config
+#

--- a/hosts
+++ b/hosts
@@ -63,8 +63,8 @@ golangVersion="1.15.5"
 
 # m13253 dns-over-https server version.
 # All releases can be seen at: https://github.com/m13253/dns-over-https/releases
-# Config provided here have only been tested for 2.2.2 & 2.2.3
-m13253DohServerVersion="2.2.3"
+# Provided config might not work with another version
+m13253DohServerVersion="2.2.4"
 
 # Dotnet runtime version to install
 # See more at: https://docs.microsoft.com/en-us/dotnet/core/install/linux-debian

--- a/playbook.yml
+++ b/playbook.yml
@@ -15,18 +15,18 @@
 
     # Calculate unbound cache based on number of cores and total ram
     # The factor 2.0 can be tweaked and is currently under assesment!
-    unbound_rrset_cache_mb: "{{ ((total_ram_mb | int) / (2.0 * (num_cores | int))) | int }}"
-    unbound_msg_cache_mb: "{{ ((unbound_rrset_cache_mb | int) * 0.5) | int }}"
-    theoretical_ubound_mem_usage_mb: "{{ (((unbound_rrset_cache_mb | int) + (unbound_msg_cache_mb | int)) | int) * (num_cores | int) }}"
+    # unbound_rrset_cache_mb: "{{ ((total_ram_mb | int) / (2.0 * (num_cores | int))) | int }}"
+    # unbound_msg_cache_mb: "{{ ((unbound_rrset_cache_mb | int) * 0.5) | int }}"
+    # theoretical_ubound_mem_usage_mb: "{{ (((unbound_rrset_cache_mb | int) + (unbound_msg_cache_mb | int)) | int) * (num_cores | int) }}"
 
   tasks:
     - debug:
         msg: "Identified machine with {{ num_cores }} cpu cores and {{ total_ram_mb }}mb RAM"
-    - debug:
-        msg: >
-          Will set unbound rrset-cache-size to {{ unbound_rrset_cache_mb }}m
-          and msg-cache-size to {{ unbound_msg_cache_mb }}m
-          which should lead to a total memory usage of {{ theoretical_ubound_mem_usage_mb }}m
+    # - debug:
+    #     msg: >
+    #       Will set unbound rrset-cache-size to {{ unbound_rrset_cache_mb }}m
+    #       and msg-cache-size to {{ unbound_msg_cache_mb }}m
+    #       which should lead to a total memory usage of {{ theoretical_ubound_mem_usage_mb }}m
 
     - name: Set system timezone to {{ timezone }}
       timezone:
@@ -272,17 +272,17 @@
         regexp: "{num_coresx2}"
         replace: "{{ (num_cores | int) * 2 | int }}"
 
-    - name: Set unbound rrset-cache-size to {{ unbound_rrset_cache_mb | int }}m
-      replace:
-        path: /etc/unbound/unbound.conf.d/ahadns.conf
-        regexp: "{rrset_cache_mb}"
-        replace: "{{ unbound_rrset_cache_mb | int }}"
+    # - name: Set unbound rrset-cache-size to {{ unbound_rrset_cache_mb | int }}m
+    #   replace:
+    #     path: /etc/unbound/unbound.conf.d/ahadns.conf
+    #     regexp: "{rrset_cache_mb}"
+    #     replace: "{{ unbound_rrset_cache_mb | int }}"
 
-    - name: Set unbound msg-cache-size to {{ unbound_msg_cache_mb | int }}m
-      replace:
-        path: /etc/unbound/unbound.conf.d/ahadns.conf
-        regexp: "{msg_cache_mb}"
-        replace: "{{ unbound_msg_cache_mb | int }}"
+    # - name: Set unbound msg-cache-size to {{ unbound_msg_cache_mb | int }}m
+    #   replace:
+    #     path: /etc/unbound/unbound.conf.d/ahadns.conf
+    #     regexp: "{msg_cache_mb}"
+    #     replace: "{{ unbound_msg_cache_mb | int }}"
 
     - name: Download DNS root hints
       get_url:
@@ -517,6 +517,8 @@
         certbot_auto_renew: true
         certbot_auto_renew_hour: "3"
         certbot_auto_renew_minute: "30"
+        certbot_auto_renew_user: root
+        certbot_auto_renew_options: '--quiet --no-self-upgrade --pre-hook "systemctl stop nginx" --post-hook "systemctl start nginx"'
         certbot_certs:
           - domains:
               - "{{ hostname }}"
@@ -534,6 +536,8 @@
         certbot_auto_renew: true
         certbot_auto_renew_hour: "3"
         certbot_auto_renew_minute: "40"
+        certbot_auto_renew_user: root
+        certbot_auto_renew_options: '--quiet --no-self-upgrade --pre-hook "systemctl stop nginx" --post-hook "systemctl start nginx"'
         certbot_certs:
           - domains:
               - "{{ dohEndpoint }}"
@@ -551,6 +555,8 @@
         certbot_auto_renew: true
         certbot_auto_renew_hour: "3"
         certbot_auto_renew_minute: "50"
+        certbot_auto_renew_user: root
+        certbot_auto_renew_options: '--quiet --no-self-upgrade --pre-hook "systemctl stop nginx" --post-hook "systemctl start nginx"'
         certbot_certs:
           - domains:
               - "{{ dotEndpoint }}"
@@ -638,6 +644,17 @@
     #
     # Install Golang
     #
+    - name: Remove old version of Golang
+      block:
+        - name: Remove current Golang version in /opt/go/ folder
+          file:
+            path: /opt/go/
+            state: absent
+        - name: Remove /etc/profile.d/golang.sh
+          file:
+            path: /etc/profile.d/golang.sh
+            state: absent
+
     - name: Setup Golang
       block:
         - name: Install Golang v{{ golangVersion }}


### PR DESCRIPTION
# Pull Request Template

## Checklist

- [x] Is CHANGELOG updated?

## Summary

- Fixed issue where certbot could not renew certificates due to permissions & nginx binding on port 80
  - Requires manual removal of all certificates and re-deploy to re-install them
- Tuning of Unbound, increased number of file descriptors
- Set static cache size for Unbound, might be changed to dynamic later when stability is confirmed
- Made golang version upgradable by always re-installing golang on each deploy
- Updated m13253 DoH server to 2.2.4
- Set version to 2.0.0 to indicate manual action needed when upgrading
  - I.e. manually delete all existing letsencrypt-certificates.

