### PR TITLE
Added config option to only allow encrypted DNS queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Type of changes can be `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Se
 
 ## [Unreleased]
 
+### Added
+
+- Added possibility to deploy DNS server that only answers encrypted DNS queries (DoT & DoH only)
+
 ### Fixed
 
 - Added installation of Curl

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Ansible playbook to easily deploy new DNS servers.
 This playbook is used to deploy all AhaDNS DNS server nodes.
+This playbook also gives you the option to deploy a server that only answers to DNS queries over encrypted channels such as DNS-over-HTTPS and DNS-over-TLS.
 
 ## Intended usecase
 
@@ -21,6 +22,10 @@ This ansible playbook deploys a fully configured AhaDNS server instance (except 
 
 All configuration that will be applied can be found in the `files` directory.
 The playbook is primarily created for AhaDNS but the public is of course welcome to use it as well.
+
+## Encrypted DNS only?
+
+By editing the variable `only_encrypted_dns` in the `hosts` file you can select to deploy a fully configured DNS server that only allows encrypted DNS queries over DNS-over-TLS and DNS-over-HTTPS. Regular unencrypted queries over port 53 will be blocked. It's recommended to set this variable to `true` whenever possible.
 
 ## Disclaimer
 

--- a/files/iptables/rules.encrypted.v4
+++ b/files/iptables/rules.encrypted.v4
@@ -1,0 +1,48 @@
+# AhaDNS ip6table rules
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT DROP [0:0]
+
+# Allow all lo input
+-A INPUT -s 127.0.0.0/8 ! -i lo -j REJECT --reject-with icmp-port-unreachable
+-A INPUT -i lo -j ACCEPT
+
+# Rate limit
+-A INPUT -i {wanInterface} -d {Ipv4Addr} -p tcp -m multiport --dports 80,443,853 -m hashlimit --hashlimit-above 100/sec --hashlimit-burst 20 --hashlimit-htable-expire 10000 --hashlimit-mode srcip --hashlimit-name dnstcp4 -j REJECT --reject-with icmp-port-unreachable
+
+# Open inputs
+-A INPUT -p tcp -m state --state NEW,ESTABLISHED -m tcp --dport {sshPort} -j ACCEPT
+-A INPUT -i {wanInterface} -d {Ipv4Addr} -p tcp -m state --state NEW,ESTABLISHED -m multiport --dports 80,443,853 -j ACCEPT
+-A INPUT -i {wanInterface} -d {Ipv4Addr} -p icmp --icmp-type echo-request -m state --state NEW,ESTABLISHED -j ACCEPT --match limit --limit 100/second
+-A INPUT -i {wanInterface} -d {Ipv4Addr} -p icmp --icmp-type echo-reply -m state --state NEW,ESTABLISHED -j ACCEPT --match limit --limit 100/second
+
+# Log rejected connections (Debugging)
+-A INPUT --match limit --limit 1/sec -j LOG --log-prefix "IPTables-Rejected: "
+
+# Allow input of Established connections
+-A INPUT -i {wanInterface} -p tcp -m state --state ESTABLISHED -j ACCEPT
+-A INPUT -i {wanInterface} -p udp -m state --state ESTABLISHED -j ACCEPT
+
+# Drop everything
+-A INPUT -j DROP
+
+# Limit output to certain ports
+-A OUTPUT -o {wanInterface} -p tcp -m state --state NEW,ESTABLISHED,RELATED -m multiport --dports 53,80,443,587 -j ACCEPT
+-A OUTPUT -o {wanInterface} -p udp -m state --state NEW,ESTABLISHED,RELATED -m multiport --dports 53 -j ACCEPT
+-A OUTPUT -o {wanInterface} -p icmp --icmp-type echo-reply -j ACCEPT --match limit --limit 60/second
+-A OUTPUT -o {wanInterface} -p icmp --icmp-type echo-request -j ACCEPT --match limit --limit 60/second
+
+# Allow output of Established connections
+-A OUTPUT -o {wanInterface} -p tcp -m state --state ESTABLISHED -j ACCEPT
+-A OUTPUT -o {wanInterface} -p udp -m state --state ESTABLISHED -j ACCEPT
+
+# Allow all local output
+-A OUTPUT -o lo -j ACCEPT
+
+# Drops
+-A OUTPUT -o {wanInterface} -j DROP
+-A OUTPUT -j DROP
+-A FORWARD -j DROP
+COMMIT
+# End

--- a/files/iptables/rules.encrypted.v6
+++ b/files/iptables/rules.encrypted.v6
@@ -1,0 +1,44 @@
+# AhaDNS ip6table rules
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT DROP [0:0]
+
+# Allow lo input
+-A INPUT -i lo -j ACCEPT
+
+# Rate limit
+-A INPUT -i {wanInterface} -d {Ipv6Addr} -p tcp -m multiport --dports 80,443,853 -m hashlimit --hashlimit-above 60/sec --hashlimit-burst 20 --hashlimit-htable-expire 10000 --hashlimit-mode srcip --hashlimit-name dnsipv6 -j REJECT
+
+# Open inputs
+-A INPUT -i {wanInterface} -d {Ipv6Addr} -p tcp -m state --state NEW,ESTABLISHED -m multiport --dports 80,443,853 -j ACCEPT
+-A INPUT -i {wanInterface} -p icmpv6 -j ACCEPT --match limit --limit 100/second
+
+# Log rejected connections (Debugging)
+-A INPUT --match limit --limit 1/sec -j LOG --log-prefix "IPTables-Rejected: "
+
+# Allow input of Established connections
+-A INPUT -i {wanInterface} -p tcp -m state --state ESTABLISHED,RELATED -j ACCEPT
+-A INPUT -i {wanInterface} -p udp -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# Drop everything else
+-A INPUT -j DROP
+
+# Limit output to certain ports
+-A OUTPUT -o {wanInterface} -p tcp -m state --state NEW,ESTABLISHED,RELATED -m multiport --dports 53,80,443,587 -j ACCEPT
+-A OUTPUT -o {wanInterface} -p udp -m state --state NEW,ESTABLISHED,RELATED -m multiport --dports 53 -j ACCEPT
+-A OUTPUT -o {wanInterface} -p icmpv6 -j ACCEPT --match limit --limit 60/second
+
+# Allow output of Established connections
+-A OUTPUT -o {wanInterface} -p tcp -m state --state ESTABLISHED -j ACCEPT
+-A OUTPUT -o {wanInterface} -p udp -m state --state ESTABLISHED -j ACCEPT
+
+# Allow all local output
+-A OUTPUT -o lo -j ACCEPT
+
+# Drops
+-A OUTPUT -o {wanInterface} -j DROP
+-A OUTPUT -j DROP
+-A FORWARD -j DROP
+COMMIT
+# End

--- a/hosts
+++ b/hosts
@@ -34,6 +34,11 @@ timezone="Europe/Stockholm"
 # and possibly to notify if automatic update fails
 email="my@email.com"
 
+# This variable determines if only encrypted
+# DNS lookups will be allowed (DoT & DoH).
+# If false, unencrypted DNS over port 53 will be allowed.
+only_encrypted_dns=false
+
 #
 # Ports
 #
@@ -72,7 +77,7 @@ dotnetVersion="3.1"
 
 # AhaDNS server statistics API version.
 # All releases can be seen at: https://github.com/AhaDNS/Aha.Dns.Statistics/releases
-ahaDnsStatisticsApiVersion="1.0.0"
+ahaDnsStatisticsApiVersion="1.0.1"
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
 
 ############################################

--- a/playbook.yml
+++ b/playbook.yml
@@ -12,7 +12,7 @@
     # Get number of CPU cores & total mb ram on machine
     num_cores: "{{ [ansible_processor_cores, ansible_processor_count, ansible_processor_vcpus] | max | int }}"
     total_ram_mb: "{{ ansible_memtotal_mb }}"
-
+    only_encrypted: "{{ only_encrypted_dns | bool }}"
     # Calculate unbound cache based on number of cores and total ram
     # The factor 2.0 can be tweaked and is currently under assesment!
     # unbound_rrset_cache_mb: "{{ ((total_ram_mb | int) / (2.0 * (num_cores | int))) | int }}"
@@ -22,6 +22,8 @@
   tasks:
     - debug:
         msg: "Identified machine with {{ num_cores }} cpu cores and {{ total_ram_mb }}mb RAM"
+    - debug:
+        msg: "Setup DNS server that only allow encrypted DNS queries: {{ only_encrypted }}"
     # - debug:
     #     msg: >
     #       Will set unbound rrset-cache-size to {{ unbound_rrset_cache_mb }}m
@@ -164,22 +166,43 @@
     #
     # IPTables setup
     #
-    - name: Setup IPTables
-      block:
+
+    # Allow public DNS
+    - name: "Setup IPTables for unencrypted DNS"
+      block :
         - name: Copy IPTables conf for IPv4
           copy:
             src: iptables/rules.v4
             dest: /etc/iptables/rules.v4
             force: yes
             mode: "0644"
-
         - name: Copy IPTables conf for IPv6
           copy:
             src: iptables/rules.v6
             dest: /etc/iptables/rules.v6
             force: yes
             mode: "0644"
+      when: not only_encrypted
 
+    # Only allow Encrypted DNS
+    - name: "Setup IPTables for Encrypted DNS only"
+      block :
+        - name: Copy IPTables conf for IPv4 (Encrypted DNS only)
+          copy:
+            src: iptables/rules.encrypted.v4
+            dest: /etc/iptables/rules.v4
+            force: yes
+            mode: "0644"
+        - name: Copy IPTables conf for IPv6 (Encrypted DNS only)
+          copy:
+            src: iptables/rules.encrypted.v6
+            dest: /etc/iptables/rules.v6
+            force: yes
+            mode: "0644"
+      when: only_encrypted
+
+    - name: Setup IPTables
+      block:
         - name: Fix windows CR/LF line endings in rules.v4
           replace:
             path: /etc/iptables/rules.v4
@@ -255,11 +278,45 @@
         force: yes
         mode: "0644"
 
-    - name: Make unbound listen to IPv6 {{ serverIpv6 }}
-      replace:
-        path: /etc/unbound/unbound.conf.d/ahadns.conf
-        regexp: "{Ipv6Addr}"
-        replace: "{{ serverIpv6 }}"
+    # --- Public DNS
+    - name: "Setup unbound to allow DNS queries from everyone"
+      block:
+        - name: Make unbound listen to IPv6 {{ serverIpv6 }}
+          replace:
+            path: /etc/unbound/unbound.conf.d/ahadns.conf
+            regexp: "{Ipv6Addr}"
+            replace: "{{ serverIpv6 }}"
+      when: not only_encrypted
+    # --- Local DNS only
+    - name: "Setup unbound to only allow queries from localhost"
+      block:
+        - name: Remove unbound listen directive for {{ serverIpv6 }}
+          lineinfile:
+              path: /etc/unbound/unbound.conf.d/ahadns.conf
+              regexp: "{Ipv6Addr}"
+              line: ""
+              state: present
+        - name: Change unbound access control 0.0.0.0/0 to 127.0.0.1/32
+          replace:
+            path: /etc/unbound/unbound.conf.d/ahadns.conf
+            regexp: "0.0.0.0/0"
+            replace: "127.0.0.1/32"
+        - name: Change unbound access control ::0/0 to ::1/128
+          replace:
+            path: /etc/unbound/unbound.conf.d/ahadns.conf
+            regexp: "::0/0"
+            replace: "::1/128"
+        - name: Make unbound listen to 127.0.0.1 only
+          replace:
+            path: /etc/unbound/unbound.conf.d/ahadns.conf
+            regexp: "0.0.0.0"
+            replace: "127.0.0.1"
+        - name: Make unbound listen to ::1 only
+          replace:
+            path: /etc/unbound/unbound.conf.d/ahadns.conf
+            regexp: "::0"
+            replace: "::1"
+      when: only_encrypted
 
     - name: Set unbound num_threads to {{ num_cores | int }}
       replace:


### PR DESCRIPTION
## Checklist

- [x] Is CHANGELOG updated?

## Summary

- Added possibility to deploy a DNS server that only responds to encrypted queries over DoT and DoH
- Fixed #20 
