### PR TITLE
Feature/update iptables ratelimit and update software

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.  
 Type of changes can be `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
 
+## [3.0.1] - 2021-05-15
+
+### Changed
+
+- Changed IPTables ratelimit rules to be more restrictive on port 53 for both ipv4 and ipv6
+- Upgraded installed golang version from 1.15.5 to 1.16.4 (latest avilable as of now)
+- Upgraded m13253's DoH server from 2.2.4 to 2.2.5
+
 ## [3.0.0] - 2021-02-13
 
 ### Added

--- a/files/iptables/rules.encrypted.v4
+++ b/files/iptables/rules.encrypted.v4
@@ -9,7 +9,7 @@
 -A INPUT -i lo -j ACCEPT
 
 # Rate limit
--A INPUT -i {wanInterface} -d {Ipv4Addr} -p tcp -m multiport --dports 80,443,853 -m hashlimit --hashlimit-above 100/sec --hashlimit-burst 20 --hashlimit-htable-expire 10000 --hashlimit-mode srcip --hashlimit-name dnstcp4 -j REJECT --reject-with icmp-port-unreachable
+-A INPUT -i {wanInterface} -d {Ipv4Addr} -p tcp -m multiport --dports 80,443,853 -m hashlimit --hashlimit-above 100/sec --hashlimit-burst 20 --hashlimit-htable-expire 10000 --hashlimit-mode srcip --hashlimit-name dnsipv4 -j REJECT --reject-with icmp-port-unreachable
 
 # Open inputs
 -A INPUT -p tcp -m state --state NEW,ESTABLISHED -m tcp --dport {sshPort} -j ACCEPT

--- a/files/iptables/rules.encrypted.v6
+++ b/files/iptables/rules.encrypted.v6
@@ -8,7 +8,7 @@
 -A INPUT -i lo -j ACCEPT
 
 # Rate limit
--A INPUT -i {wanInterface} -d {Ipv6Addr} -p tcp -m multiport --dports 80,443,853 -m hashlimit --hashlimit-above 60/sec --hashlimit-burst 20 --hashlimit-htable-expire 10000 --hashlimit-mode srcip --hashlimit-name dnsipv6 -j REJECT
+-A INPUT -i {wanInterface} -d {Ipv6Addr} -p tcp -m multiport --dports 80,443,853 -m hashlimit --hashlimit-above 40/sec --hashlimit-burst 20 --hashlimit-htable-expire 10000 --hashlimit-mode srcip --hashlimit-name dnsipv6 -j REJECT
 
 # Open inputs
 -A INPUT -i {wanInterface} -d {Ipv6Addr} -p tcp -m state --state NEW,ESTABLISHED -m multiport --dports 80,443,853 -j ACCEPT

--- a/files/iptables/rules.v4
+++ b/files/iptables/rules.v4
@@ -20,8 +20,9 @@
 -A INPUT -i lo -j ACCEPT
 
 # Rate limit
--A INPUT -i {wanInterface} -d {Ipv4Addr} -p tcp -m multiport --dports 53,80,443,853 -m hashlimit --hashlimit-above 100/sec --hashlimit-burst 20 --hashlimit-htable-expire 10000 --hashlimit-mode srcip --hashlimit-name dnstcp4 -j REJECT --reject-with icmp-port-unreachable
--A INPUT -i {wanInterface} -d {Ipv4Addr} -p udp --dport 53 -m hashlimit --hashlimit-above 100/sec --hashlimit-burst 20 --hashlimit-htable-expire 10000 --hashlimit-mode srcip --hashlimit-name dnsudp4 -j REJECT --reject-with icmp-port-unreachable
+-A INPUT -i {wanInterface} -d {Ipv4Addr} -p tcp --dport 53 -m hashlimit --hashlimit-above 50/sec --hashlimit-burst 10 --hashlimit-htable-expire 10000 --hashlimit-mode srcip --hashlimit-name dnsipv4 -j DROP
+-A INPUT -i {wanInterface} -d {Ipv4Addr} -p udp --dport 53 -m hashlimit --hashlimit-above 50/sec --hashlimit-burst 10 --hashlimit-htable-expire 10000 --hashlimit-mode srcip --hashlimit-name dnsipv4 -j DROP
+-A INPUT -i {wanInterface} -d {Ipv4Addr} -p tcp -m multiport --dports 80,443,853 -m hashlimit --hashlimit-above 100/sec --hashlimit-burst 20 --hashlimit-htable-expire 10000 --hashlimit-mode srcip --hashlimit-name dnsipv4 -j REJECT --reject-with icmp-port-unreachable
 
 # Open inputs
 -A INPUT -p tcp -m state --state NEW,ESTABLISHED -m tcp --dport {sshPort} -j ACCEPT

--- a/files/iptables/rules.v6
+++ b/files/iptables/rules.v6
@@ -42,7 +42,7 @@
 # Limit output to certain ports
 -A OUTPUT -o {wanInterface} -p tcp -m state --state NEW,ESTABLISHED,RELATED -m multiport --dports 53,80,443,587 -j ACCEPT
 -A OUTPUT -o {wanInterface} -p udp -m state --state NEW,ESTABLISHED,RELATED -m multiport --dports 53 -j ACCEPT
--A OUTPUT -o {wanInterface} -p icmpv6 -j ACCEPT --match limit --limit 100/second
+-A OUTPUT -o {wanInterface} -p icmpv6 -j ACCEPT --match limit --limit 60/second
 
 # Allow output of Established connections
 -A OUTPUT -o {wanInterface} -p tcp -m state --state ESTABLISHED -j ACCEPT

--- a/files/iptables/rules.v6
+++ b/files/iptables/rules.v6
@@ -19,8 +19,9 @@
 -A INPUT -i lo -j ACCEPT
 
 # Rate limit
--A INPUT -i {wanInterface} -d {Ipv6Addr} -p udp --dport 53 -m hashlimit --hashlimit-above 60/sec --hashlimit-burst 20 --hashlimit-htable-expire 10000 --hashlimit-mode srcip --hashlimit-name dnsipv6 -j REJECT
--A INPUT -i {wanInterface} -d {Ipv6Addr} -p tcp -m multiport --dports 80,443,53,853 -m hashlimit --hashlimit-above 60/sec --hashlimit-burst 20 --hashlimit-htable-expire 10000 --hashlimit-mode srcip --hashlimit-name dnsipv6 -j REJECT
+-A INPUT -i {wanInterface} -d {Ipv6Addr} -p udp --dport 53 -m hashlimit --hashlimit-above 20/sec --hashlimit-burst 10 --hashlimit-htable-expire 10000 --hashlimit-mode srcip --hashlimit-name dnsipv6 -j DROP
+-A INPUT -i {wanInterface} -d {Ipv6Addr} -p tcp --dport 53 -m hashlimit --hashlimit-above 20/sec --hashlimit-burst 10 --hashlimit-htable-expire 10000 --hashlimit-mode srcip --hashlimit-name dnsipv6 -j DROP
+-A INPUT -i {wanInterface} -d {Ipv6Addr} -p tcp -m multiport --dports 80,443,853 -m hashlimit --hashlimit-above 40/sec --hashlimit-burst 20 --hashlimit-htable-expire 10000 --hashlimit-mode srcip --hashlimit-name dnsipv6 -j REJECT
 
 # Open inputs
 -A INPUT -i {wanInterface} -d {Ipv6Addr} -p tcp -m state --state NEW,ESTABLISHED -m multiport --dports 53,80,443,853 -j ACCEPT
@@ -41,7 +42,7 @@
 # Limit output to certain ports
 -A OUTPUT -o {wanInterface} -p tcp -m state --state NEW,ESTABLISHED,RELATED -m multiport --dports 53,80,443,587 -j ACCEPT
 -A OUTPUT -o {wanInterface} -p udp -m state --state NEW,ESTABLISHED,RELATED -m multiport --dports 53 -j ACCEPT
--A OUTPUT -o {wanInterface} -p icmpv6 -j ACCEPT --match limit --limit 60/second
+-A OUTPUT -o {wanInterface} -p icmpv6 -j ACCEPT --match limit --limit 100/second
 
 # Allow output of Established connections
 -A OUTPUT -o {wanInterface} -p tcp -m state --state ESTABLISHED -j ACCEPT

--- a/hosts
+++ b/hosts
@@ -64,12 +64,12 @@ ahaDnsStatisticsApiKey="supersecret"
 
 # Golang version to install.
 # Available version can be seen at: https://galaxy.ansible.com/gantsign/golang
-golangVersion="1.15.5"
+golangVersion="1.16.4"
 
 # m13253 dns-over-https server version.
 # All releases can be seen at: https://github.com/m13253/dns-over-https/releases
 # Provided config might not work with another version
-m13253DohServerVersion="2.2.4"
+m13253DohServerVersion="2.2.5"
 
 # Dotnet runtime version to install
 # See more at: https://docs.microsoft.com/en-us/dotnet/core/install/linux-debian

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,2 @@
 - src: gantsign.golang
 - src: geerlingguy.certbot
-- src: dev-sec.ssh-hardening


### PR DESCRIPTION
# Pull Request Template

## Checklist

- [x] Is CHANGELOG updated?

## Summary

- Changed IPTables ratelimit rules to be more restrictive on port 53 for both ipv4 and ipv6
- Upgraded installed golang version from 1.15.5 to 1.16.4 (latest avilable as of now)
- Upgraded m13253's DoH server from 2.2.4 to 2.2.5
